### PR TITLE
fix(security): bump vulnerable dependencies and verify in Docker

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2217,14 +2217,14 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.27"
+version = "0.0.31"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"},
-    {file = "python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602"},
+    {file = "python_multipart-0.0.31-py3-none-any.whl", hash = "sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28"},
+    {file = "python_multipart-0.0.31.tar.gz", hash = "sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680"},
 ]
 
 [[package]]
@@ -2708,14 +2708,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "starlette"
-version = "1.2.1"
+version = "1.3.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89"},
-    {file = "starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6"},
+    {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
+    {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
 ]
 
 [package.dependencies]
@@ -2723,7 +2723,7 @@ anyio = ">=3.6.2,<5"
 typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+full = ["httpx (>=0.27.0,<0.29.0)", "httpx2 (>=2.0.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "sympy"
@@ -2936,22 +2936,22 @@ pyyaml = ["pyyaml"]
 
 [[package]]
 name = "tornado"
-version = "6.5.5"
+version = "6.5.7"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa"},
-    {file = "tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521"},
-    {file = "tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5"},
-    {file = "tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07"},
-    {file = "tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e"},
-    {file = "tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca"},
-    {file = "tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7"},
-    {file = "tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b"},
-    {file = "tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6"},
-    {file = "tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9"},
+    {file = "tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163"},
+    {file = "tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100"},
+    {file = "tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972"},
+    {file = "tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b"},
+    {file = "tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92"},
+    {file = "tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5"},
+    {file = "tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4"},
+    {file = "tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4"},
+    {file = "tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796"},
+    {file = "tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2"},
 ]
 
 [[package]]
@@ -3103,4 +3103,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "7568cbaf016800be4f452485cfa75bb2f0596615c9b258c373ca40b9959603df"
+content-hash = "e0eb24517dfa5127fcdcc85fca4320a0ac2ad1195267da724bf7fcd4504852c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
 fastapi = "^0.136.3"
-starlette = ">=1.0.1,<2.0.0" # CVE-2026-48710 対策
+starlette = ">=1.3.1,<2.0.0" # CVE-2026-48710 / -54282 / -54283 対策
 uvicorn = "^0.29.0"
 pydantic = "^2.9.0"
 pydantic-settings = "^2.0.0"
 python-dotenv = "^1.0.1"
 pymongo = "^4.7.2"
-python-multipart = "^0.0.27" # CVE-2026-42561 対策
+python-multipart = "^0.0.31" # CVE-2026-42561 / -53537 / -53538 / -53539 / -53540 対策
 openai-whisper = "^20250625"
 levenshtein = "^0.25.1"
 pytz = "^2024.1"
@@ -31,6 +31,7 @@ ipython = "^8.15.0"
 ipykernel = "^6.25.2"
 pytest = "^9.0.3"
 httpx = "^0.27.0"
+tornado = ">=6.5.7,<7.0.0" # CVE-2026-49853 / -49854 / -49855 対策
 
 [build-system]
 requires = ["poetry-core"]

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=f".env.{os.getenv('ENV', 'dev')}",
         env_file_encoding="utf-8",
+        extra="ignore",
     )
 
     def __init__(self, **data):


### PR DESCRIPTION
## 概要

Dependabot の未解消アラートに対応し、依存更新を Docker 環境で `poetry lock` とテストまで確認します。

## 変更内容

- `starlette` を `>=1.3.1` に更新し、CVE-2026-48710 / CVE-2026-54282 / CVE-2026-54283 に対応
- `python-multipart` を `^0.0.31` に更新し、CVE-2026-42561 / CVE-2026-53537 / CVE-2026-53538 / CVE-2026-53539 / CVE-2026-53540 に対応
- 開発依存に `tornado >= 6.5.7` を明示し、CVE-2026-49853 / CVE-2026-49854 / CVE-2026-49855 系に対応
- `server/utils/config.py` で `extra="ignore"` を追加し、`.env.dev` の補助キーで `Settings` 初期化が落ちないよう修正

## Docker 確認

- `docker build -f Dockerfile.test -t auto-unlock-server-vuln .`
- `docker run --rm --env-file .env.dev -v /home/yamashita/workspace/auto-unlock-server:/root/workspace -w /root/workspace auto-unlock-server-vuln poetry lock`
- `docker run --rm --env-file .env.dev -v /home/yamashita/workspace/auto-unlock-server:/root/workspace -w /root/workspace auto-unlock-server-vuln pytest tests/test_host_validation.py -q`
- 結果: `3 passed`

## 未解消

- `torch` の GHSA-rrmf-rvhw-rf47 / CVE-2025-3000 は 2026-06-18 時点で patched version が公開されていないため今回は対象外