### PR TITLE
fix: remediate pydantic-settings advisory

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2018,14 +2018,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
-    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
+    {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
+    {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
 ]
 
 [package.dependencies]
@@ -3103,4 +3103,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "e0eb24517dfa5127fcdcc85fca4320a0ac2ad1195267da724bf7fcd4504852c6"
+content-hash = "6b6b9f79c39196bd1e3b4c47e6fd5cfc2326703d9c97952d0ed63da55c56980f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ fastapi = "^0.136.3"
 starlette = ">=1.3.1,<2.0.0" # CVE-2026-48710 / -54282 / -54283 対策
 uvicorn = "^0.29.0"
 pydantic = "^2.9.0"
-pydantic-settings = "^2.0.0"
+pydantic-settings = "^2.14.2"
 python-dotenv = "^1.0.1"
 pymongo = "^4.7.2"
 python-multipart = "^0.0.31" # CVE-2026-42561 / -53537 / -53538 / -53539 / -53540 対策

--- a/skills/repo-vulnerability-release/SKILL.md
+++ b/skills/repo-vulnerability-release/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: repo-vulnerability-release
+description: Handle repository vulnerability remediation end-to-end for this repo. Use when Codex needs to respond to dependency or framework security alerts by creating a dedicated branch, updating vulnerable packages, regenerating lockfiles, verifying the changes inside Docker with `poetry lock` and tests, then committing, pushing, merging, tagging, and publishing a GitHub release.
+---
+
+# Repo Vulnerability Release
+
+Follow this workflow for security remediation in this repository.
+
+## Workflow
+
+1. Create a dedicated branch before making remediation changes.
+2. Identify open vulnerability alerts with `gh api repos/nglcobdai/auto-unlock-server/dependabot/alerts`.
+3. Prefer the smallest dependency change that closes the alert while fitting the existing dependency graph.
+4. Update `pyproject.toml` constraints when direct dependencies need a higher minimum version.
+5. Regenerate `poetry.lock`.
+6. Verify inside Docker, not just on the host machine.
+7. Commit only the remediation changes.
+8. Push the branch, open or update a PR, merge to `dev`, create the next patch tag, and publish a GitHub release.
+
+## Docker Verification
+
+Use `.env.dev`. Do not create `.env.test`.
+
+Build the test image from `Dockerfile.test`, then run verification commands inside that container with the repository mounted:
+
+```bash
+docker build -f Dockerfile.test -t auto-unlock-server-vuln .
+docker run --rm --env-file .env.dev -v "$PWD:/root/workspace" -w /root/workspace auto-unlock-server-vuln poetry lock
+docker run --rm --env-file .env.dev -v "$PWD:/root/workspace" -w /root/workspace auto-unlock-server-vuln pytest tests/test_host_validation.py -q
+```
+
+If the touched area warrants broader coverage, run the smallest additional test set that exercises the changed dependency or behavior.
+
+## Git And Release
+
+Use this repository's existing release flow:
+
+1. Push the remediation branch to `origin`.
+2. Create a PR targeting `dev`.
+3. Merge the PR after verification.
+4. Fetch `origin/dev` and tag the merge commit with the next patch version, for example `v1.2.4`.
+5. Publish a GitHub release from that tag with concise notes naming the addressed advisories and the Docker verification performed.
+
+## Notes
+
+- Keep vulnerability comments in `pyproject.toml` up to date when they explain why a minimum version exists.
+- If GitHub shows an open alert with no patched version, record that clearly and avoid inventing a fake fix.
+- Prefer `gh` for Dependabot, PR, tag, and release operations.

--- a/skills/repo-vulnerability-release/agents/openai.yaml
+++ b/skills/repo-vulnerability-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Vulnerability Release"
+  short_description: "Repo vuln fix, docker verify, release flow"
+  default_prompt: "Use $repo-vulnerability-release to handle dependency vulnerabilities end-to-end for this repository."


### PR DESCRIPTION
## Summary
- bump pydantic-settings to the first patched release for GHSA-4xgf-cpjx-pc3j
- regenerate poetry.lock and verify inside Docker with .env.dev
- add a repo-local skill documenting the vulnerability remediation and release workflow

## Verification
- docker build -f Dockerfile.test -t auto-unlock-server-vuln .
- docker run --rm --env-file .env.dev -v /home/yamashita/workspace/auto-unlock-server:/root/workspace -w /root/workspace auto-unlock-server-vuln poetry lock
- docker run --rm --env-file .env.dev -v /home/yamashita/workspace/auto-unlock-server:/root/workspace -w /root/workspace auto-unlock-server-vuln pytest tests/test_host_validation.py -q

## Notes
- GitHub still reports GHSA-rrmf-rvhw-rf47 for torch, but no patched version is available upstream yet.