### PR TITLE
fix: handle torch advisory usage

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,10 +3,12 @@ FROM nvidia/cuda:12.1.0-cudnn8-runtime-ubuntu22.04
 ENV LANG=C.UTF-8 \
     LANGUAGE=en_US \
     PYTHONPATH="/root/workspace:$PYTHONPATH" \
+    POETRY_HOME="/opt/poetry" \
+    PATH="/opt/poetry/bin:$PATH" \
     DEBIAN_FRONTEND=noninteractive
 
 # Pythonのインストール
-RUN apt-get update && apt-get install -y python3.10 python3-pip \
+RUN apt-get update && apt-get install -y python3.10 python3-pip python3.10-venv \
     && ln -s /usr/bin/python3.10 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
@@ -18,8 +20,9 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /root/workspace
 
 # Poetryのインストールと依存関係のインストール
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --upgrade poetry
+RUN python3.10 -m venv $POETRY_HOME \
+    && $POETRY_HOME/bin/pip install --upgrade pip \
+    && $POETRY_HOME/bin/pip install poetry
 
 # pyproject.toml、poetry.lock、poetry.tomlをコピーする
 COPY pyproject.toml poetry.lock poetry.toml $WORKDIR/

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -3,10 +3,12 @@ FROM nvidia/cuda:12.1.0-cudnn8-runtime-ubuntu22.04
 ENV LANG=C.UTF-8 \
     LANGUAGE=en_US \
     PYTHONPATH="/root/workspace:$PYTHONPATH" \
+    POETRY_HOME="/opt/poetry" \
+    PATH="/opt/poetry/bin:$PATH" \
     DEBIAN_FRONTEND=noninteractive
 
 # Pythonのインストール
-RUN apt-get update && apt-get install -y python3.10 python3-pip \
+RUN apt-get update && apt-get install -y python3.10 python3-pip python3.10-venv \
     && ln -s /usr/bin/python3.10 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
@@ -18,8 +20,9 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /root/workspace
 
 # Poetryのインストールと依存関係のインストール
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --upgrade poetry
+RUN python3.10 -m venv $POETRY_HOME \
+    && $POETRY_HOME/bin/pip install --upgrade pip \
+    && $POETRY_HOME/bin/pip install poetry
 
 # pyproject.toml、poetry.lock、poetry.tomlをコピーする
 COPY pyproject.toml poetry.lock poetry.toml $WORKDIR/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,6 +3,8 @@ FROM ubuntu:22.04
 ENV LANG=C.UTF-8 \
     LANGUAGE=en_US \
     PYTHONPATH="/root/workspace/app:$PYTHONPATH" \
+    POETRY_HOME="/opt/poetry" \
+    PATH="/opt/poetry/bin:$PATH" \
     DEBIAN_FRONTEND=noninteractive
 
 # 基本ツールのインストール
@@ -10,7 +12,7 @@ RUN apt-get update && apt-get install -y wget gnupg software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
 # Pythonのインストール
-RUN apt-get update && apt-get install -y python3.10 python3-pip \
+RUN apt-get update && apt-get install -y python3.10 python3-pip python3.10-venv \
     && ln -s /usr/bin/python3.10 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
@@ -35,8 +37,9 @@ WORKDIR /root/workspace
 COPY pyproject.toml poetry.lock poetry.toml $WORKDIR/
 
 # Poetryのインストールと依存関係のインストール
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --upgrade poetry
+RUN python3.10 -m venv $POETRY_HOME \
+    && $POETRY_HOME/bin/pip install --upgrade pip \
+    && $POETRY_HOME/bin/pip install poetry
 
 # Temporary directory for Poetry and torch installation
 ENV TMPDIR=/root/workspace/tmp

--- a/docs/security/GHSA-rrmf-rvhw-rf47.md
+++ b/docs/security/GHSA-rrmf-rvhw-rf47.md
@@ -1,0 +1,23 @@
+# GHSA-rrmf-rvhw-rf47
+
+## Status
+
+- Advisory: `GHSA-rrmf-rvhw-rf47` / `CVE-2025-3000`
+- Package: `torch`
+- GitHub alert: `#48`
+- Last reviewed: `2026-07-09`
+
+## Repository assessment
+
+This service depends on `torch` through Whisper model loading, but the application code only uses:
+
+- `whisper.load_model(...)`
+- `model.transcribe(...)`
+
+The advisory is specific to `torch.jit.script`, and the repository does not call that API in `server/`.
+
+## Handling
+
+- Keep the GitHub Dependabot alert dismissed only while no patched upstream version exists.
+- Re-check the advisory metadata before each dependency refresh or security release.
+- The regression test in `tests/test_torch_jit_usage.py` prevents accidental introduction of `torch.jit.script`.

--- a/tests/test_torch_jit_usage.py
+++ b/tests/test_torch_jit_usage.py
@@ -1,0 +1,34 @@
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SERVER_ROOT = REPO_ROOT / "server"
+
+
+def _attribute_chain(node):
+    parts = []
+    current = node
+
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        return ".".join(reversed(parts))
+
+    return None
+
+
+def test_server_code_does_not_call_torch_jit_script():
+    for path in SERVER_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func_name = _attribute_chain(node.func)
+                assert func_name != "torch.jit.script", (
+                    f"{path.relative_to(REPO_ROOT)} must not call torch.jit.script() "
+                    "while GHSA-rrmf-rvhw-rf47 remains unpatched upstream."
+                )


### PR DESCRIPTION
## Summary
- document why GHSA-rrmf-rvhw-rf47 is not exercised by this service
- add a regression test preventing direct torch.jit.script usage in server code
- fix Docker Poetry installation so the required container verification flow succeeds again

## Verification
- docker build -f Dockerfile.test -t auto-unlock-server-vuln .
- docker run --rm --env-file .env.dev -v /home/yamashita/workspace/auto-unlock-server:/root/workspace -w /root/workspace auto-unlock-server-vuln poetry lock
- docker run --rm --env-file .env.dev -v /home/yamashita/workspace/auto-unlock-server:/root/workspace -w /root/workspace auto-unlock-server-vuln pytest tests/test_host_validation.py tests/test_torch_jit_usage.py -q

## Notes
- GitHub advisory #48 reports torch as vulnerable through torch.jit.script with no patched upstream version published yet.
- This service uses Whisper model loading and transcription, and the server code does not call torch.jit.script.